### PR TITLE
🐞 fix: 使用detach结束控制台侦听进程

### DIFF
--- a/src/server/core/ConsoleInput.cpp
+++ b/src/server/core/ConsoleInput.cpp
@@ -14,7 +14,7 @@ ConsoleInput::ConsoleInput(asio::io_context& io_context)
 
 ConsoleInput::~ConsoleInput()
 {
-    m_thread.join();
+    m_thread.detach();
 }
 
 void ConsoleInput::register_command(const std::string& command, CommandHandler handler)


### PR DESCRIPTION
使用stop命令停止后consoleInput进程仍然继续侦听输入导致无法停止，需要手动在输入最后一次任意按键结束getline()。

现在修改为使用detach直接终止consoleInput进程。

Signed-off-by: Aurorabili <aurorabili@outlook.com>